### PR TITLE
Fix typo in aspect ratio hook comment

### DIFF
--- a/hooks/canvas-area-hooks/use-automatic-aspect-ratio-switcher.ts
+++ b/hooks/canvas-area-hooks/use-automatic-aspect-ratio-switcher.ts
@@ -4,7 +4,7 @@ import { useResizeCanvas } from '@/store/use-resize-canvas'
 import React, { useEffect } from 'react'
 
 /**
- * This hook encaspulates the logic used to automatically switch the aspect ratio of a screenshot
+ * This hook encapsulates the logic used to automatically switch the aspect ratio of a screenshot
  * within a container. If the screenshot overflows the container, the aspect
  * ratio is adjusted to fit within the container.
  *


### PR DESCRIPTION
## Summary
- fix the word "encaspulates" in the automatic aspect ratio switcher hook

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a88c6cb488322af19243095c94ad5