### PR TITLE
Fix equal canvas size calculation

### DIFF
--- a/utils/helper-fns.ts
+++ b/utils/helper-fns.ts
@@ -27,18 +27,11 @@ export function calculateEqualCanvasSize(
   imgHeight: number,
   padding: number
 ) {
-  const aspectRatio = imgWidth / imgHeight
-  let canvasWidth, canvasHeight
+  // Calculate a square canvas by adding padding based on the longest side
+  const maxDimension = Math.max(imgWidth, imgHeight)
+  const canvasSize = maxDimension + 2 * padding
 
-  if (aspectRatio > 1) {
-    canvasWidth = imgWidth + 2 * padding
-    canvasHeight = imgHeight + 2 * padding
-  } else {
-    canvasHeight = imgHeight + 2 * padding
-    canvasWidth = imgWidth + 2 * padding
-  }
-
-  return `${canvasWidth}x${canvasHeight}`
+  return `${canvasSize}x${canvasSize}`
 }
 
 export function capitalize(str: string) {


### PR DESCRIPTION
## Summary
- fix calculation for equal padding canvas size in helper function

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a86a8cd8c8322b0e7363d8b3f5f33