### PR TITLE
Refactor image retrieval helpers

### DIFF
--- a/components/editor/image-options/inset-option.tsx
+++ b/components/editor/image-options/inset-option.tsx
@@ -11,7 +11,7 @@ import {
 import { Button } from '@/components/ui/button'
 
 export default function InsetOption() {
-  const { images, setImages } = useImageOptions()
+  const { images, updateImageStyle, getImage } = useImageOptions()
   const { setShowControls, showControls } = useMoveable()
   const { selectedImage } = useSelectedLayers()
 
@@ -26,7 +26,7 @@ export default function InsetOption() {
                 className="ml-2 h-5 w-5 rounded-md"
                 style={{
                   backgroundColor: selectedImage
-                    ? images[selectedImage - 1]?.style.insetColor
+                    ? getImage(selectedImage)?.style.insetColor
                     : '#fff',
                 }}
                 variant="outline"
@@ -55,19 +55,10 @@ export default function InsetOption() {
                           }`}
                           style={{ backgroundColor: color.color }}
                           onClick={() => {
-                            setImages(
-                              images.map((image, index) =>
-                                index === selectedImage! - 1
-                                  ? {
-                                      ...image,
-                                      style: {
-                                        ...image.style,
-                                        insetColor: color.color,
-                                      },
-                                    }
-                                  : image
-                              )
-                            )
+                            selectedImage &&
+                              updateImageStyle(selectedImage, {
+                                insetColor: color.color,
+                              })
                           }}
                         />
                       )
@@ -89,65 +80,39 @@ export default function InsetOption() {
           onValueChange={(value: number[]) => {
             setShowControls(false)
             selectedImage &&
-              setImages(
-                images.map((image, index) =>
-                  index === selectedImage - 1
-                    ? {
-                        ...image,
-                        style: {
-                          ...image.style,
-                          insetSize: value[0].toString(),
-                        },
-                      }
-                    : image
-                )
-              )
+              updateImageStyle(selectedImage, {
+                insetSize: value[0].toString(),
+              })
           }}
           value={
             images.length !== 0 && selectedImage
-              ? [+images[selectedImage - 1]?.style.insetSize]
+              ? [+(getImage(selectedImage)?.style.insetSize ?? 0)]
               : [10]
           }
           onValueCommit={() => setShowControls(true)}
           onIncrement={() => {
             setShowControls(false)
             selectedImage &&
-              setImages(
-                images.map((image, index) =>
-                  index === selectedImage - 1
-                    ? {
-                        ...image,
-                        style: {
-                          ...image.style,
-                          insetSize:
-                            +image.style.insetSize <= 149
-                              ? (+image.style.insetSize + 4).toString()
-                              : '150',
-                        },
-                      }
-                    : image
-                )
-              )
+              updateImageStyle(selectedImage, {
+                insetSize:
+                  +(getImage(selectedImage)?.style.insetSize ?? 0) <= 149
+                    ? (
+                        +(getImage(selectedImage)?.style.insetSize ?? 0) + 4
+                      ).toString()
+                    : '150',
+              })
           }}
           onDecrement={() => {
             setShowControls(false)
             selectedImage &&
-              setImages(
-                images.map((image, index) =>
-                  index === selectedImage - 1
-                    ? {
-                        ...image,
-                        style: {
-                          ...image.style,
-                          insetSize:
-                            +image.style.insetSize >= 0
-                              ? (+image.style.insetSize - 4).toString()
-                              : '0',
-                        },
-                      }
-                    : image
-                )
-              )
+              updateImageStyle(selectedImage, {
+                insetSize:
+                  +(getImage(selectedImage)?.style.insetSize ?? 0) >= 0
+                    ? (
+                        +(getImage(selectedImage)?.style.insetSize ?? 0) - 4
+                      ).toString()
+                    : '0',
+              })
           }}
         />
       </div>

--- a/components/editor/image-options/roundness-option.tsx
+++ b/components/editor/image-options/roundness-option.tsx
@@ -5,11 +5,11 @@ import { useImageOptions, useSelectedLayers } from '@/store/use-image-options'
 import { useMoveable } from '@/store/use-moveable'
 
 export default function RoundnessOption() {
-  const { images, setImages } = useImageOptions()
+  const { images, updateImageStyle, getImage } = useImageOptions()
   const { setShowControls } = useMoveable()
   const { selectedImage } = useSelectedLayers()
 
-  const browserFrame = selectedImage ? images[selectedImage - 1]?.frame : 'None'
+  const browserFrame = selectedImage ? getImage(selectedImage)?.frame : 'None'
 
   return (
     <div className={`${selectedImage ? '' : 'pointer-events-none opacity-40'}`}>
@@ -19,7 +19,7 @@ export default function RoundnessOption() {
           {`${Math.round(
             Number(
               selectedImage
-                ? images[selectedImage - 1]?.style.imageRoundness
+                ? getImage(selectedImage)?.style.imageRoundness
                 : 0.2
             ) * 10
           )} `}
@@ -35,65 +35,35 @@ export default function RoundnessOption() {
           onValueChange={(value) => {
             setShowControls(false)
             selectedImage &&
-              setImages(
-                images.map((image, index) =>
-                  index === selectedImage - 1
-                    ? {
-                        ...image,
-                        style: {
-                          ...image.style,
-                          imageRoundness: value[0],
-                        },
-                      }
-                    : image
-                )
-              )
+              updateImageStyle(selectedImage, { imageRoundness: value[0] })
           }}
           value={
             images.length !== 0 && selectedImage
-              ? [+images[selectedImage - 1]?.style.imageRoundness]
+              ? [+(getImage(selectedImage)?.style.imageRoundness ?? 1)]
               : [1]
           }
           onValueCommit={() => setShowControls(true)}
           onIncrement={() => {
             if (images.length === 0 || !selectedImage) return
-            if (Number(images[selectedImage - 1]?.style.imageRoundness) >= 5)
+            if (Number(getImage(selectedImage)?.style.imageRoundness) >= 5)
               return
             setShowControls(false)
-            setImages(
-              images.map((image, index) =>
-                index === selectedImage - 1
-                  ? {
-                      ...image,
-                      style: {
-                        ...image.style,
-                        imageRoundness:
-                          Number(image.style.imageRoundness) + 0.1,
-                      },
-                    }
-                  : image
-              )
-            )
+            updateImageStyle(selectedImage, {
+              imageRoundness:
+                Number(getImage(selectedImage)?.style.imageRoundness ?? 0) +
+                0.1,
+            })
           }}
           onDecrement={() => {
             if (images.length === 0 || !selectedImage) return
-            if (Number(images[selectedImage - 1]?.style.imageRoundness) <= 0)
+            if (Number(getImage(selectedImage)?.style.imageRoundness) <= 0)
               return
             setShowControls(false)
-            setImages(
-              images.map((image, index) =>
-                index === selectedImage - 1
-                  ? {
-                      ...image,
-                      style: {
-                        ...image.style,
-                        imageRoundness:
-                          Number(image.style.imageRoundness) - 0.1,
-                      },
-                    }
-                  : image
-              )
-            )
+            updateImageStyle(selectedImage, {
+              imageRoundness:
+                Number(getImage(selectedImage)?.style.imageRoundness ?? 0) -
+                0.1,
+            })
           }}
         />
       </div>

--- a/components/editor/main-image-area.tsx
+++ b/components/editor/main-image-area.tsx
@@ -25,7 +25,9 @@ const ImageUpload = () => {
   const targetRef = useRef<HTMLDivElement>(null)
   const {
     images,
-    setImages,
+    addImage,
+    updateImage,
+    updateImageStyle,
 
     setInitialImageUploaded,
     initialImageUploaded,
@@ -54,21 +56,10 @@ const ImageUpload = () => {
 
       const extractedColors = result.slice(0, 12)
 
-      setImages(
-        images.map((image, index) =>
-          index === images.length - 1
-            ? {
-                ...image,
-                extractedColors,
-                // gradientColors,
-                style: {
-                  ...image.style,
-                  insetColor: extractedColors[0].color,
-                },
-              }
-            : image
-        )
-      )
+      updateImage(images.length, { extractedColors })
+      updateImageStyle(images.length, {
+        insetColor: extractedColors[0].color,
+      })
     }
     extractColors()
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -317,8 +308,13 @@ const ImageUpload = () => {
 export default ImageUpload
 
 function LoadAImage() {
-  const { images, setImages, defaultStyle, setInitialImageUploaded } =
-    useImageOptions()
+  const {
+    images,
+    addImage,
+    updateImage,
+    defaultStyle,
+    setInitialImageUploaded,
+  } = useImageOptions()
   const { setSelectedImage } = useSelectedLayers()
   const { imagesCheck, setImagesCheck } = useColorExtractor()
   const { setResolution, automaticResolution } = useResizeCanvas()
@@ -338,10 +334,7 @@ function LoadAImage() {
             const imageUrl = URL.createObjectURL(file)
             setInitialImageUploaded(true)
             setImagesCheck([...imagesCheck, imageUrl])
-            setImages([
-              ...images,
-              { image: imageUrl, id: images.length + 1, style: defaultStyle },
-            ])
+            addImage({ image: imageUrl, id: images.length + 1, style: defaultStyle })
             setSelectedImage(images.length + 1)
 
             if (images.length === 0 && automaticResolution) {
@@ -366,7 +359,7 @@ function LoadAImage() {
 
     document.addEventListener('paste', handlePaste)
     return () => document.removeEventListener('paste', handlePaste)
-  }, [images, imagesCheck, setImages, setImagesCheck, setInitialImageUploaded, setSelectedImage, defaultStyle, automaticResolution, setResolution])
+  }, [images, imagesCheck, addImage, setImagesCheck, setInitialImageUploaded, setSelectedImage, defaultStyle, automaticResolution, setResolution])
 
   const handleImageLoad = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -377,10 +370,7 @@ function LoadAImage() {
         setInitialImageUploaded(true)
 
         setImagesCheck([...imagesCheck, imageUrl])
-        setImages([
-          ...images,
-          { image: imageUrl, id: images.length + 1, style: defaultStyle },
-        ])
+        addImage({ image: imageUrl, id: images.length + 1, style: defaultStyle })
         setSelectedImage(images.length + 1)
 
         if (images.length > 0) return
@@ -405,7 +395,6 @@ function LoadAImage() {
       setInitialImageUploaded,
       setImagesCheck,
       imagesCheck,
-      setImages,
       images,
       defaultStyle,
       setSelectedImage,
@@ -423,10 +412,7 @@ function LoadAImage() {
         setInitialImageUploaded(true)
 
         setImagesCheck([...imagesCheck, imageUrl])
-        setImages([
-          ...images,
-          { image: imageUrl, id: images.length + 1, style: defaultStyle },
-        ])
+        addImage({ image: imageUrl, id: images.length + 1, style: defaultStyle })
         setSelectedImage(images.length + 1)
 
         if (images.length > 0) return
@@ -451,7 +437,6 @@ function LoadAImage() {
       setInitialImageUploaded,
       setImagesCheck,
       imagesCheck,
-      setImages,
       images,
       defaultStyle,
       setSelectedImage,
@@ -467,20 +452,17 @@ function LoadAImage() {
       '--gradient-bg',
       ' linear-gradient(var(--gradient-angle), #898aeb, #d8b9e3)'
     )
-    setImages([
-      ...images,
-      {
-        image: demoImage.src,
-        id: 1,
-        style: {
-          ...defaultStyle,
-          borderSize: '15',
-          imageRoundness: 0.7,
-          imageSize: '0.78',
-          insetSize: '10',
-        },
+    addImage({
+      image: demoImage.src,
+      id: 1,
+      style: {
+        ...defaultStyle,
+        borderSize: '15',
+        imageRoundness: 0.7,
+        imageSize: '0.78',
+        insetSize: '10',
       },
-    ])
+    })
     setImagesCheck([...imagesCheck, demoImage.src])
     setResolution('1920x1080')
   }

--- a/store/use-image-options.ts
+++ b/store/use-image-options.ts
@@ -3,6 +3,42 @@ import { temporal, TemporalState } from 'zundo'
 import throttle from 'just-throttle'
 import { FrameTypes } from './use-frame-options'
 
+export interface ImageStyle {
+  imageSize: string
+  imageRoundness: number
+  imageShadow: string
+  shadowPreview: string
+  shadowName: string
+  shadowOpacity: number
+  shadowColor: string
+  borderSize: string | null
+  borderColor: string
+  insetSize: string
+  insetColor: string
+  rotate: string
+  rotateX: number
+  rotateY: number
+  rotateZ: number
+  perspective: number
+  translateX: number
+  translateY: number
+  zIndex: number
+  hasFrame?: boolean
+}
+
+export interface ImageItem {
+  id: number
+  image: string
+  extractedColors?: { color: string; count: number }[]
+  linearGradients?: string[]
+  meshGradients?: string[]
+  radialGradients?: string[]
+  dominantColor?: string
+  pallettes?: string[]
+  style: ImageStyle
+  frame?: FrameTypes
+}
+
 interface ImageOptionsState {
   scale: number
   setScale: (scale: number) => void
@@ -21,72 +57,13 @@ interface ImageOptionsState {
   initialImageUploaded: boolean
   setInitialImageUploaded: (initialImageUploaded: boolean) => void
 
-  images: {
-    id: number
-    image: string
-    extractedColors?: { color: string; count: number }[]
-    linearGradients?: string[]
-    meshGradients?: string[]
-    radialGradients?: string[]
-    dominantColor?: string
-    pallettes?: string[]
-    style: {
-      imageSize: string
-      imageRoundness: number
-      imageShadow: string
-      shadowName: string
-      shadowOpacity: number
-      shadowPreview: string
-      shadowColor: string
-      borderSize: string | null
-      borderColor: string
-      insetSize: string
-      insetColor: string
-      rotate: string
-      rotateX: number
-      rotateY: number
-      rotateZ: number
-      perspective: number
-      translateX: number
-      translateY: number
-      zIndex: number
-    }
-    frame?: FrameTypes
-  }[]
-  setImages: (
-    images: {
-      id: number
-      image: string
-      extractedColors?: { color: string; count: number }[]
-      linearGradients?: string[]
-      meshGradients?: string[]
-      radialGradients?: string[]
-      dominantColor?: string
-      pallettes?: string[]
-      style: {
-        imageSize: string
-        imageRoundness: number
-        imageShadow: string
-        shadowOpacity: number
-        shadowPreview: string
-        shadowName: string
-        shadowColor: string
-        borderSize: string | null
-        borderColor: string
-        insetSize: string
-        insetColor: string
-        rotate: string
-        rotateX: number
-        rotateY: number
-        rotateZ: number
-        perspective: number
-        translateX: number
-        translateY: number
-        zIndex: number
-      }
-      frame?: FrameTypes
-    }[]
-  ) => void
+  images: ImageItem[]
+  setImages: (images: ImageItem[]) => void
+  addImage: (image: ImageItem) => void
+  updateImageStyle: (id: number, style: Partial<ImageStyle>) => void
+  updateImage: (id: number, data: Partial<ImageItem>) => void
+  getImage: (id: number) => ImageItem | undefined
+  getImageIndex: (id: number) => number
 
   texts: {
     id: number
@@ -176,7 +153,7 @@ interface ImageOptionsState {
 
 export const useImageOptions = create(
   temporal<ImageOptionsState>(
-    (set) => ({
+    (set, get) => ({
       scale: 1,
       setScale: (scale) => set({ scale }),
 
@@ -234,6 +211,30 @@ export const useImageOptions = create(
 
       images: [],
       setImages: (images) => set({ images }),
+      addImage: (image) =>
+        set((state) => ({
+          images: [...state.images, image],
+        })),
+      updateImageStyle: (id, style) =>
+        set((state) => ({
+          images: state.images.map((img) =>
+            img.id === id ? { ...img, style: { ...img.style, ...style } } : img
+          ),
+        })),
+      updateImage: (id, data) =>
+        set((state) => ({
+          images: state.images.map((img) =>
+            img.id === id
+              ? {
+                  ...img,
+                  ...data,
+                  style: { ...img.style, ...(data.style ?? {}) },
+                }
+              : img
+          ),
+        })),
+      getImage: (id) => get().images.find((img) => img.id === id),
+      getImageIndex: (id) => get().images.findIndex((img) => img.id === id),
 
       texts: [],
       setTexts: (texts) => set({ texts }),


### PR DESCRIPTION
## Summary
- add `getImage` and `getImageIndex` helpers in image store
- expose new helpers in `useImageOptions`
- update inset and roundness options to read styles via `getImage`
- include `hasFrame` flag in `ImageStyle`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_684abb3577908322b5c2038642449b37