### PR TITLE
Add user settings dialog

### DIFF
--- a/app/api/user/settings/route.ts
+++ b/app/api/user/settings/route.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod'
+import { NextResponse } from 'next/server'
+import prismadb from '@/libs/prismadb'
+import { getCurrentSession } from '@/utils/auth-options'
+import { userSettingsSchema } from '@/libs/validators/user-settings-validator'
+
+export async function PATCH(request: Request) {
+  try {
+    const session = await getCurrentSession()
+    if (!session) {
+      return new NextResponse('Unauthorized', { status: 401 })
+    }
+
+    const body = await request.json()
+    const { name, image } = userSettingsSchema.parse(body)
+
+    await prismadb.user.update({
+      where: { id: session.user.id },
+      data: {
+        name: name ?? undefined,
+        image: image ?? undefined,
+      },
+    })
+
+    return new NextResponse('OK')
+  } catch (error) {
+    console.log(error)
+    if (error instanceof z.ZodError) {
+      return new NextResponse(error.message, { status: 400 })
+    }
+    return new NextResponse('Something went wrong', { status: 500 })
+  }
+}

--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -1,7 +1,13 @@
 'use client'
 
-import { useState } from 'react'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { Drawer, DrawerContent } from '@/components/ui/drawer'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -16,9 +22,15 @@ interface SettingsDialogProps {
 export default function SettingsDialog({ children }: SettingsDialogProps) {
   const isDesktop = useMediaQuery('(min-width: 768px)')
   const [open, setOpen] = useState(false)
+  const router = useRouter()
   const { data: session, update } = useSession()
   const [name, setName] = useState(session?.user?.name || '')
   const [image, setImage] = useState(session?.user?.image || '')
+
+  useEffect(() => {
+    setName(session?.user?.name || '')
+    setImage(session?.user?.image || '')
+  }, [session])
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -31,7 +43,8 @@ export default function SettingsDialog({ children }: SettingsDialogProps) {
       if (!res.ok) {
         throw new Error(await res.text())
       }
-      await update()
+      await update({ name, image })
+      router.refresh()
       toast({ title: 'Profile updated!' })
       setOpen(false)
     } catch (error: any) {

--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useState } from 'react'
-import { Dialog, DialogContent, DialogTrigger, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { Drawer, DrawerContent, DrawerTrigger } from '@/components/ui/drawer'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Drawer, DrawerContent } from '@/components/ui/drawer'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useMediaQuery } from '@/hooks/use-media-query'
@@ -49,13 +49,21 @@ export default function SettingsDialog({ children }: SettingsDialogProps) {
         <label htmlFor="name" className="text-sm font-medium">
           Username
         </label>
-        <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+        <Input
+          id="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
       </div>
       <div className="space-y-1">
         <label htmlFor="image" className="text-sm font-medium">
           Image URL
         </label>
-        <Input id="image" value={image || ''} onChange={(e) => setImage(e.target.value)} />
+        <Input
+          id="image"
+          value={image || ''}
+          onChange={(e) => setImage(e.target.value)}
+        />
       </div>
       <Button type="submit" className="w-full">
         Save
@@ -66,7 +74,7 @@ export default function SettingsDialog({ children }: SettingsDialogProps) {
   if (isDesktop) {
     return (
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogTrigger asChild>{children}</DialogTrigger>
+        {children}
         <DialogContent className="p-6">
           <DialogHeader>
             <DialogTitle>Edit profile</DialogTitle>
@@ -79,7 +87,7 @@ export default function SettingsDialog({ children }: SettingsDialogProps) {
 
   return (
     <Drawer open={open} onOpenChange={setOpen}>
-      <DrawerTrigger asChild>{children}</DrawerTrigger>
+      {children}
       <DrawerContent className="mb-6 rounded-xl bg-[#121212] px-6 py-2">
         <div className="mt-8" />
         {Form}

--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useState } from 'react'
+import { Dialog, DialogContent, DialogTrigger, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Drawer, DrawerContent, DrawerTrigger } from '@/components/ui/drawer'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useMediaQuery } from '@/hooks/use-media-query'
+import { toast } from '@/hooks/use-toast'
+import { useSession } from 'next-auth/react'
+
+interface SettingsDialogProps {
+  children: React.ReactNode
+}
+
+export default function SettingsDialog({ children }: SettingsDialogProps) {
+  const isDesktop = useMediaQuery('(min-width: 768px)')
+  const [open, setOpen] = useState(false)
+  const { data: session, update } = useSession()
+  const [name, setName] = useState(session?.user?.name || '')
+  const [image, setImage] = useState(session?.user?.image || '')
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      const res = await fetch('/api/user/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, image }),
+      })
+      if (!res.ok) {
+        throw new Error(await res.text())
+      }
+      await update()
+      toast({ title: 'Profile updated!' })
+      setOpen(false)
+    } catch (error: any) {
+      toast({
+        title: 'Error updating profile',
+        description: error.message,
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const Form = (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <div className="space-y-1">
+        <label htmlFor="name" className="text-sm font-medium">
+          Username
+        </label>
+        <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+      </div>
+      <div className="space-y-1">
+        <label htmlFor="image" className="text-sm font-medium">
+          Image URL
+        </label>
+        <Input id="image" value={image || ''} onChange={(e) => setImage(e.target.value)} />
+      </div>
+      <Button type="submit" className="w-full">
+        Save
+      </Button>
+    </form>
+  )
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>{children}</DialogTrigger>
+        <DialogContent className="p-6">
+          <DialogHeader>
+            <DialogTitle>Edit profile</DialogTitle>
+          </DialogHeader>
+          {Form}
+        </DialogContent>
+      </Dialog>
+    )
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <DrawerTrigger asChild>{children}</DrawerTrigger>
+      <DrawerContent className="mb-6 rounded-xl bg-[#121212] px-6 py-2">
+        <div className="mt-8" />
+        {Form}
+        <div className="mt-4" />
+      </DrawerContent>
+    </Drawer>
+  )
+}

--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -49,7 +49,7 @@ export default function SettingsDialog({ children }: SettingsDialogProps) {
       if (!res.ok) {
         throw new Error(await res.text())
       }
-      await update({ name, image })
+      await update()
       router.refresh()
       toast({ title: 'Profile updated!' })
       setOpen(false)

--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -8,12 +8,18 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Drawer, DrawerContent } from '@/components/ui/drawer'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useMediaQuery } from '@/hooks/use-media-query'
 import { toast } from '@/hooks/use-toast'
 import { useSession } from 'next-auth/react'
+import { Image as ImageIcon, Save, Settings as SettingsIcon, User as UserIcon } from 'lucide-react'
 
 interface SettingsDialogProps {
   children: React.ReactNode
@@ -62,24 +68,39 @@ export default function SettingsDialog({ children }: SettingsDialogProps) {
         <label htmlFor="name" className="text-sm font-medium">
           Username
         </label>
-        <Input
-          id="name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
+        <div className="relative">
+          <Input
+            id="name"
+            className="pl-9"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <UserIcon
+            size={16}
+            className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+          />
+        </div>
       </div>
       <div className="space-y-1">
         <label htmlFor="image" className="text-sm font-medium">
           Image URL
         </label>
-        <Input
-          id="image"
-          value={image || ''}
-          onChange={(e) => setImage(e.target.value)}
-        />
+        <div className="relative">
+          <Input
+            id="image"
+            className="pl-9"
+            value={image || ''}
+            onChange={(e) => setImage(e.target.value)}
+          />
+          <ImageIcon
+            size={16}
+            className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+          />
+        </div>
       </div>
-      <Button type="submit" className="w-full">
-        Save
+      <Button type="submit" className="flex w-full items-center justify-center gap-2">
+        <Save size={16} />
+        <span>Save</span>
       </Button>
     </form>
   )
@@ -90,7 +111,10 @@ export default function SettingsDialog({ children }: SettingsDialogProps) {
         {children}
         <DialogContent className="p-6">
           <DialogHeader>
-            <DialogTitle>Edit profile</DialogTitle>
+            <DialogTitle className="mb-4 flex items-center gap-1.5">
+              <SettingsIcon size={18} className="opacity-80" />
+              <span>Edit profile</span>
+            </DialogTitle>
           </DialogHeader>
           {Form}
         </DialogContent>
@@ -101,8 +125,13 @@ export default function SettingsDialog({ children }: SettingsDialogProps) {
   return (
     <Drawer open={open} onOpenChange={setOpen}>
       {children}
-      <DrawerContent className="mb-6 rounded-xl bg-[#121212] px-6 py-2">
-        <div className="mt-8" />
+      <DrawerContent className="mb-6 rounded-xl bg-[#121212] px-6 py-4">
+        <DrawerHeader className="text-left">
+          <DrawerTitle className="mb-4 flex items-center gap-1.5">
+            <SettingsIcon size={18} className="opacity-80" />
+            <span>Edit profile</span>
+          </DrawerTitle>
+        </DrawerHeader>
         {Form}
         <div className="mt-4" />
       </DrawerContent>

--- a/components/user-dropdown.tsx
+++ b/components/user-dropdown.tsx
@@ -4,6 +4,7 @@
 
 import { Button } from '@/components/ui/button'
 import SettingsDialog from './settings-dialog'
+import { DialogTrigger } from '@/components/ui/dialog'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -49,10 +50,11 @@ export const UserDropDown = ({
   }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild className="group flex items-center">
-        <Button
-          variant="ghost"
+    <SettingsDialog>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild className="group flex items-center">
+          <Button
+            variant="ghost"
           className="flex h-10 cursor-pointer items-center justify-center gap-x-2.5 rounded-xl bg-[#181818] px-4 py-2 font-medium text-dark"
         >
           <div className="h-7 w-7 overflow-hidden ">
@@ -88,7 +90,7 @@ export const UserDropDown = ({
           {menuItems.map((item, index) => (
             <React.Fragment key={item.label}>
               {item.isSettings ? (
-                <SettingsDialog>
+                <DialogTrigger asChild>
                   <DropdownMenuItem
                     className={`group cursor-pointer rounded-lg focus:bg-white ${
                       index !== menuItems.length - 1 ? 'mb-1' : ''
@@ -104,7 +106,7 @@ export const UserDropDown = ({
                       </span>
                     </div>
                   </DropdownMenuItem>
-                </SettingsDialog>
+                </DialogTrigger>
               ) : (
                 <DropdownMenuItem
                   className={`group cursor-pointer rounded-lg focus:bg-white ${
@@ -137,5 +139,6 @@ export const UserDropDown = ({
         </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
+    </SettingsDialog>
   )
 }

--- a/components/user-dropdown.tsx
+++ b/components/user-dropdown.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { Button } from '@/components/ui/button'
+import SettingsDialog from './settings-dialog'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,7 +20,7 @@ import React from 'react'
 
 const menuItems = [
   { href: '/profile', icon: User, label: 'Profile' },
-  { href: '/settings', icon: Settings, label: 'Settings' },
+  { icon: Settings, label: 'Settings', isSettings: true },
   { href: '/upgrade', icon: Zap, label: 'Upgrade', separateFromHere: true },
   { icon: LogOut, label: 'Logout' },
 ]
@@ -86,28 +87,45 @@ export const UserDropDown = ({
         <DropdownMenuGroup>
           {menuItems.map((item, index) => (
             <React.Fragment key={item.label}>
-              <DropdownMenuItem
-                className={`group cursor-pointer rounded-lg focus:bg-white ${
-                  index !== menuItems.length - 1 ? 'mb-1' : ''
-                }`}
-                key={item.href}
-                onClick={() =>
-                  item.label === 'Logout' ? handleSignOut() : null
-                }
-              >
-                <div
-                  // href={item.href}
-                  className="flex w-full items-center focus:shadow-md"
+              {item.isSettings ? (
+                <SettingsDialog>
+                  <DropdownMenuItem
+                    className={`group cursor-pointer rounded-lg focus:bg-white ${
+                      index !== menuItems.length - 1 ? 'mb-1' : ''
+                    }`}
+                  >
+                    <div className="flex w-full items-center focus:shadow-md">
+                      <item.icon
+                        size={18}
+                        className="mr-3 h-4 w-4  text-dark/80 group-focus:text-black/90"
+                      />
+                      <span className="font-medium group-focus:text-black/90">
+                        {item.label}
+                      </span>
+                    </div>
+                  </DropdownMenuItem>
+                </SettingsDialog>
+              ) : (
+                <DropdownMenuItem
+                  className={`group cursor-pointer rounded-lg focus:bg-white ${
+                    index !== menuItems.length - 1 ? 'mb-1' : ''
+                  }`}
+                  key={item.href}
+                  onClick={() =>
+                    item.label === 'Logout' ? handleSignOut() : null
+                  }
                 >
-                  <item.icon
-                    size={18}
-                    className="mr-3 h-4 w-4  text-dark/80 group-focus:text-black/90"
-                  />
-                  <span className="font-medium group-focus:text-black/90">
-                    {item.label}
-                  </span>
-                </div>
-              </DropdownMenuItem>
+                  <div className="flex w-full items-center focus:shadow-md">
+                    <item.icon
+                      size={18}
+                      className="mr-3 h-4 w-4  text-dark/80 group-focus:text-black/90"
+                    />
+                    <span className="font-medium group-focus:text-black/90">
+                      {item.label}
+                    </span>
+                  </div>
+                </DropdownMenuItem>
+              )}
               {item.separateFromHere && (
                 <DropdownMenuSeparator
                   key={item.label}

--- a/libs/validators/user-settings-validator.ts
+++ b/libs/validators/user-settings-validator.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod'
+
+export const userSettingsSchema = z.object({
+  name: z.string().min(1).max(50).optional(),
+  image: z.string().url().optional(),
+})


### PR DESCRIPTION
## Summary
- add `SettingsDialog` component for editing name and image
- wrap settings option in dropdown to open the dialog
- create `/api/user/settings` route to update profile
- add `userSettingsSchema` validator

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_6856fd8990f88322a9781699f72a2991