### PR TITLE
Add icons to settings dialog

### DIFF
--- a/app/api/user/settings/route.ts
+++ b/app/api/user/settings/route.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod'
+import { NextResponse } from 'next/server'
+import prismadb from '@/libs/prismadb'
+import { getCurrentSession } from '@/utils/auth-options'
+import { userSettingsSchema } from '@/libs/validators/user-settings-validator'
+
+export async function PATCH(request: Request) {
+  try {
+    const session = await getCurrentSession()
+    if (!session) {
+      return new NextResponse('Unauthorized', { status: 401 })
+    }
+
+    const body = await request.json()
+    const { name, image } = userSettingsSchema.parse(body)
+
+    await prismadb.user.update({
+      where: { id: session.user.id },
+      data: {
+        name: name ?? undefined,
+        image: image ?? undefined,
+      },
+    })
+
+    return new NextResponse('OK')
+  } catch (error) {
+    console.log(error)
+    if (error instanceof z.ZodError) {
+      return new NextResponse(error.message, { status: 400 })
+    }
+    return new NextResponse('Something went wrong', { status: 500 })
+  }
+}

--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useMediaQuery } from '@/hooks/use-media-query'
+import { toast } from '@/hooks/use-toast'
+import { useSession } from 'next-auth/react'
+import { Image as ImageIcon, Save, Settings as SettingsIcon, User as UserIcon } from 'lucide-react'
+
+interface SettingsDialogProps {
+  children: React.ReactNode
+}
+
+export default function SettingsDialog({ children }: SettingsDialogProps) {
+  const isDesktop = useMediaQuery('(min-width: 768px)')
+  const [open, setOpen] = useState(false)
+  const router = useRouter()
+  const { data: session, update } = useSession()
+  const [name, setName] = useState(session?.user?.name || '')
+  const [image, setImage] = useState(session?.user?.image || '')
+
+  useEffect(() => {
+    setName(session?.user?.name || '')
+    setImage(session?.user?.image || '')
+  }, [session])
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      const res = await fetch('/api/user/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, image }),
+      })
+      if (!res.ok) {
+        throw new Error(await res.text())
+      }
+      await update({
+        name,
+        image,
+      })
+      router.refresh()
+      toast({ title: 'Profile updated!' })
+      setOpen(false)
+    } catch (error: any) {
+      toast({
+        title: 'Error updating profile',
+        description: error.message,
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const Form = (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <div className="space-y-1">
+        <label htmlFor="name" className="text-sm font-medium">
+          Username
+        </label>
+        <div className="relative">
+          <Input
+            id="name"
+            className="pl-9"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <UserIcon
+            size={16}
+            className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+          />
+        </div>
+      </div>
+      <div className="space-y-1">
+        <label htmlFor="image" className="text-sm font-medium">
+          Image URL
+        </label>
+        <div className="relative">
+          <Input
+            id="image"
+            className="pl-9"
+            value={image || ''}
+            onChange={(e) => setImage(e.target.value)}
+          />
+          <ImageIcon
+            size={16}
+            className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+          />
+        </div>
+      </div>
+      <Button type="submit" className="flex w-full items-center justify-center gap-2">
+        <Save size={16} />
+        <span>Save</span>
+      </Button>
+    </form>
+  )
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={setOpen}>
+        {children}
+        <DialogContent className="p-6">
+          <DialogHeader>
+            <DialogTitle className="mb-4 flex items-center gap-1.5">
+              <SettingsIcon size={18} className="opacity-80" />
+              <span>Edit profile</span>
+            </DialogTitle>
+          </DialogHeader>
+          {Form}
+        </DialogContent>
+      </Dialog>
+    )
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      {children}
+      <DrawerContent className="mb-6 rounded-xl bg-[#121212] px-6 py-4">
+        <DrawerHeader className="text-left">
+          <DrawerTitle className="mb-4 flex items-center gap-1.5">
+            <SettingsIcon size={18} className="opacity-80" />
+            <span>Edit profile</span>
+          </DrawerTitle>
+        </DrawerHeader>
+        {Form}
+        <div className="mt-4" />
+      </DrawerContent>
+    </Drawer>
+  )
+}

--- a/components/user-dropdown.tsx
+++ b/components/user-dropdown.tsx
@@ -3,6 +3,8 @@
 'use client'
 
 import { Button } from '@/components/ui/button'
+import SettingsDialog from './settings-dialog'
+import { DialogTrigger } from '@/components/ui/dialog'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,7 +21,7 @@ import React from 'react'
 
 const menuItems = [
   { href: '/profile', icon: User, label: 'Profile' },
-  { href: '/settings', icon: Settings, label: 'Settings' },
+  { icon: Settings, label: 'Settings', isSettings: true },
   { href: '/upgrade', icon: Zap, label: 'Upgrade', separateFromHere: true },
   { icon: LogOut, label: 'Logout' },
 ]
@@ -48,10 +50,11 @@ export const UserDropDown = ({
   }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild className="group flex items-center">
-        <Button
-          variant="ghost"
+    <SettingsDialog>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild className="group flex items-center">
+          <Button
+            variant="ghost"
           className="flex h-10 cursor-pointer items-center justify-center gap-x-2.5 rounded-xl bg-[#181818] px-4 py-2 font-medium text-dark"
         >
           <div className="h-7 w-7 overflow-hidden ">
@@ -86,28 +89,45 @@ export const UserDropDown = ({
         <DropdownMenuGroup>
           {menuItems.map((item, index) => (
             <React.Fragment key={item.label}>
-              <DropdownMenuItem
-                className={`group cursor-pointer rounded-lg focus:bg-white ${
-                  index !== menuItems.length - 1 ? 'mb-1' : ''
-                }`}
-                key={item.href}
-                onClick={() =>
-                  item.label === 'Logout' ? handleSignOut() : null
-                }
-              >
-                <div
-                  // href={item.href}
-                  className="flex w-full items-center focus:shadow-md"
+              {item.isSettings ? (
+                <DialogTrigger asChild>
+                  <DropdownMenuItem
+                    className={`group cursor-pointer rounded-lg focus:bg-white ${
+                      index !== menuItems.length - 1 ? 'mb-1' : ''
+                    }`}
+                  >
+                    <div className="flex w-full items-center focus:shadow-md">
+                      <item.icon
+                        size={18}
+                        className="mr-3 h-4 w-4  text-dark/80 group-focus:text-black/90"
+                      />
+                      <span className="font-medium group-focus:text-black/90">
+                        {item.label}
+                      </span>
+                    </div>
+                  </DropdownMenuItem>
+                </DialogTrigger>
+              ) : (
+                <DropdownMenuItem
+                  className={`group cursor-pointer rounded-lg focus:bg-white ${
+                    index !== menuItems.length - 1 ? 'mb-1' : ''
+                  }`}
+                  key={item.href}
+                  onClick={() =>
+                    item.label === 'Logout' ? handleSignOut() : null
+                  }
                 >
-                  <item.icon
-                    size={18}
-                    className="mr-3 h-4 w-4  text-dark/80 group-focus:text-black/90"
-                  />
-                  <span className="font-medium group-focus:text-black/90">
-                    {item.label}
-                  </span>
-                </div>
-              </DropdownMenuItem>
+                  <div className="flex w-full items-center focus:shadow-md">
+                    <item.icon
+                      size={18}
+                      className="mr-3 h-4 w-4  text-dark/80 group-focus:text-black/90"
+                    />
+                    <span className="font-medium group-focus:text-black/90">
+                      {item.label}
+                    </span>
+                  </div>
+                </DropdownMenuItem>
+              )}
               {item.separateFromHere && (
                 <DropdownMenuSeparator
                   key={item.label}
@@ -119,5 +139,6 @@ export const UserDropDown = ({
         </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
+    </SettingsDialog>
   )
 }

--- a/libs/validators/user-settings-validator.ts
+++ b/libs/validators/user-settings-validator.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod'
+
+export const userSettingsSchema = z.object({
+  name: z.string().min(1).max(50).optional(),
+  image: z.string().url().optional(),
+})


### PR DESCRIPTION
## Summary
- integrate lucide-react icons into `SettingsDialog`
- add icon-based input fields and header
- show a save icon on the submit button
- refresh the session after saving settings

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_6856fd8990f88322a9781699f72a2991