### PR TITLE
Add profile dialog

### DIFF
--- a/components/profile-dialog.tsx
+++ b/components/profile-dialog.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import { useSession } from 'next-auth/react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer'
+import { useMediaQuery } from '@/hooks/use-media-query'
+import { formatDate } from '@/utils/helper-fns'
+
+interface ProfileDialogProps {
+  children: React.ReactNode
+}
+
+export default function ProfileDialog({ children }: ProfileDialogProps) {
+  const isDesktop = useMediaQuery('(min-width: 768px)')
+  const [open, setOpen] = useState(false)
+  const { data: session } = useSession()
+
+  const initials = session?.user?.name
+    ?.split(' ')
+    .map((n) => n[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase()
+
+  const Content = (
+    <div className="flex flex-col items-center gap-2 text-center">
+      <div className="mb-4 flex h-24 w-24 items-center justify-center overflow-hidden rounded-full border-2 border-border">
+        {session?.user?.image ? (
+          <Image
+            src={session.user.image}
+            alt={session.user.name || 'user'}
+            width={96}
+            height={96}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-muted text-3xl font-semibold text-[#898AEB]">
+            {initials}
+          </div>
+        )}
+      </div>
+      <p className="text-lg font-semibold">{session?.user?.name}</p>
+      {session?.user?.createdAt && (
+        <p className="text-sm text-muted-foreground">
+          Joined {formatDate(session.user.createdAt)}
+        </p>
+      )}
+    </div>
+  )
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={setOpen}>
+        {children}
+        <DialogContent className="p-6 text-center">
+          <DialogHeader>
+            <DialogTitle className="mb-4">Profile</DialogTitle>
+          </DialogHeader>
+          {Content}
+        </DialogContent>
+      </Dialog>
+    )
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      {children}
+      <DrawerContent className="mb-6 rounded-xl bg-[#121212] px-6 py-4 text-center">
+        <DrawerHeader>
+          <DrawerTitle className="mb-4">Profile</DrawerTitle>
+        </DrawerHeader>
+        {Content}
+        <div className="mt-4" />
+      </DrawerContent>
+    </Drawer>
+  )
+}

--- a/components/user-dropdown.tsx
+++ b/components/user-dropdown.tsx
@@ -4,6 +4,7 @@
 
 import { Button } from '@/components/ui/button'
 import SettingsDialog from './settings-dialog'
+import ProfileDialog from './profile-dialog'
 import { DialogTrigger } from '@/components/ui/dialog'
 import {
   DropdownMenu,
@@ -20,7 +21,7 @@ import Image from 'next/image'
 import React from 'react'
 
 const menuItems = [
-  { href: '/profile', icon: User, label: 'Profile' },
+  { icon: User, label: 'Profile', isProfile: true },
   { icon: Settings, label: 'Settings', isSettings: true },
   { href: '/upgrade', icon: Zap, label: 'Upgrade', separateFromHere: true },
   { icon: LogOut, label: 'Logout' },
@@ -50,11 +51,10 @@ export const UserDropDown = ({
   }
 
   return (
-    <SettingsDialog>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild className="group flex items-center">
-          <Button
-            variant="ghost"
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild className="group flex items-center">
+        <Button
+          variant="ghost"
           className="flex h-10 cursor-pointer items-center justify-center gap-x-2.5 rounded-xl bg-[#181818] px-4 py-2 font-medium text-dark"
         >
           <div className="h-7 w-7 overflow-hidden ">
@@ -89,24 +89,46 @@ export const UserDropDown = ({
         <DropdownMenuGroup>
           {menuItems.map((item, index) => (
             <React.Fragment key={item.label}>
-              {item.isSettings ? (
-                <DialogTrigger asChild>
-                  <DropdownMenuItem
-                    className={`group cursor-pointer rounded-lg focus:bg-white ${
-                      index !== menuItems.length - 1 ? 'mb-1' : ''
-                    }`}
-                  >
-                    <div className="flex w-full items-center focus:shadow-md">
-                      <item.icon
-                        size={18}
-                        className="mr-3 h-4 w-4  text-dark/80 group-focus:text-black/90"
-                      />
-                      <span className="font-medium group-focus:text-black/90">
-                        {item.label}
-                      </span>
-                    </div>
-                  </DropdownMenuItem>
-                </DialogTrigger>
+              {item.isProfile ? (
+                <ProfileDialog>
+                  <DialogTrigger asChild>
+                    <DropdownMenuItem
+                      className={`group cursor-pointer rounded-lg focus:bg-white ${
+                        index !== menuItems.length - 1 ? 'mb-1' : ''
+                      }`}
+                    >
+                      <div className="flex w-full items-center focus:shadow-md">
+                        <item.icon
+                          size={18}
+                          className="mr-3 h-4 w-4  text-dark/80 group-focus:text-black/90"
+                        />
+                        <span className="font-medium group-focus:text-black/90">
+                          {item.label}
+                        </span>
+                      </div>
+                    </DropdownMenuItem>
+                  </DialogTrigger>
+                </ProfileDialog>
+              ) : item.isSettings ? (
+                <SettingsDialog>
+                  <DialogTrigger asChild>
+                    <DropdownMenuItem
+                      className={`group cursor-pointer rounded-lg focus:bg-white ${
+                        index !== menuItems.length - 1 ? 'mb-1' : ''
+                      }`}
+                    >
+                      <div className="flex w-full items-center focus:shadow-md">
+                        <item.icon
+                          size={18}
+                          className="mr-3 h-4 w-4  text-dark/80 group-focus:text-black/90"
+                        />
+                        <span className="font-medium group-focus:text-black/90">
+                          {item.label}
+                        </span>
+                      </div>
+                    </DropdownMenuItem>
+                  </DialogTrigger>
+                </SettingsDialog>
               ) : (
                 <DropdownMenuItem
                   className={`group cursor-pointer rounded-lg focus:bg-white ${
@@ -139,6 +161,5 @@ export const UserDropDown = ({
         </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
-    </SettingsDialog>
   )
 }

--- a/utils/auth-options.ts
+++ b/utils/auth-options.ts
@@ -13,7 +13,16 @@ declare module 'next-auth' {
     user: {
       id: string
       isCreator: boolean
+      createdAt: string
     } & DefaultSession['user']
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    id: string
+    isCreator: boolean
+    createdAt: string
   }
 }
 
@@ -41,6 +50,8 @@ export const authOptions: NextAuthOptions = {
           id: user.id,
           // @ts-expect-error isCreator is there but its not showing
           isCreator: user?.isCreator,
+          // @ts-expect-error createdAt is on user model
+          createdAt: user?.createdAt,
         }
       }
 
@@ -54,6 +65,7 @@ export const authOptions: NextAuthOptions = {
           ...session.user,
           id: token.id,
           isCreator: token.isCreator,
+          createdAt: token.createdAt,
         },
       }
     },


### PR DESCRIPTION
## Summary
- provide a profile dialog in the user menu
- expose user's `createdAt` timestamp in session

## Testing
- `pnpm lint`
- `pnpm exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_6857111f828c832282b40af15033ed29