### PR TITLE
Add profile dialog with user join info

### DIFF
--- a/app/api/user/settings/route.ts
+++ b/app/api/user/settings/route.ts
@@ -19,6 +19,7 @@ export async function GET() {
         email: true,
         image: true,
         isCreator: true,
+        createdAt: true,
       },
     })
 

--- a/components/editor/background-options/normal-gradient-picker.tsx
+++ b/components/editor/background-options/normal-gradient-picker.tsx
@@ -356,7 +356,7 @@ export default function NormalGradientPicker() {
         <span>Gradients:</span>
       </h3>
 
-      <div className="mt-4 w-full flex grid-cols-7 flex-wrap gap-[0.5rem] md:grid">
+      <div className="mt-4 flex w-full grid-cols-7 flex-wrap gap-[0.5rem] md:grid">
         {gradients.map(({ gradient, background, type }: Gradient) => (
           <Button
             key={gradient}

--- a/components/profile-dialog.tsx
+++ b/components/profile-dialog.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import Image from 'next/image'
+import { User as UserIcon } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer'
+import { useMediaQuery } from '@/hooks/use-media-query'
+import { formatDate } from '@/utils/helper-fns'
+
+interface ProfileDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export default function ProfileDialog({ open, onOpenChange }: ProfileDialogProps) {
+  const isDesktop = useMediaQuery('(min-width: 768px)')
+  const { data } = useSession()
+  const [joined, setJoined] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function fetchJoinDate() {
+      try {
+        const res = await fetch('/api/user/settings')
+        if (res.ok) {
+          const json = await res.json()
+          if (json?.database?.createdAt) {
+            setJoined(formatDate(json.database.createdAt))
+          }
+        }
+      } catch {
+        // ignore
+      }
+    }
+    if (open) fetchJoinDate()
+  }, [open])
+
+  const name = data?.user?.name || 'User'
+  const image = data?.user?.image || ''
+
+  const initials = name
+    .split(' ')
+    .map((n) => n.charAt(0))
+    .join('')
+    .slice(0, 2)
+    .toUpperCase()
+
+  const avatar = image ? (
+    <Image
+      src={image}
+      alt={name}
+      width={80}
+      height={80}
+      className="h-20 w-20 rounded-full object-cover"
+    />
+  ) : (
+    <div className="flex h-20 w-20 items-center justify-center rounded-full bg-muted text-xl font-semibold">
+      {initials}
+    </div>
+  )
+
+  const Body = (
+    <div className="flex flex-col items-center space-y-2">
+      {avatar}
+      <p className="text-lg font-semibold">{name}</p>
+      {joined && <p className="text-sm text-muted-foreground">Joined {joined}</p>}
+    </div>
+  )
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="p-6">
+          <DialogHeader>
+            <DialogTitle className="mb-4 flex items-center gap-1.5">
+              <UserIcon size={18} className="opacity-80" />
+              <span>Profile</span>
+            </DialogTitle>
+          </DialogHeader>
+          {Body}
+        </DialogContent>
+      </Dialog>
+    )
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className="mb-6 rounded-xl bg-[#121212] px-6 py-4">
+        <DrawerHeader className="text-left">
+          <DrawerTitle className="mb-4 flex items-center gap-1.5">
+            <UserIcon size={18} className="opacity-80" />
+            <span>Profile</span>
+          </DrawerTitle>
+        </DrawerHeader>
+        {Body}
+        <div className="mt-4" />
+      </DrawerContent>
+    </Drawer>
+  )
+}

--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -22,12 +22,12 @@ import { useSession } from 'next-auth/react'
 import { Image as ImageIcon, Save, Settings as SettingsIcon, User as UserIcon } from 'lucide-react'
 
 interface SettingsDialogProps {
-  children: React.ReactNode
+  open: boolean
+  onOpenChange: (open: boolean) => void
 }
 
-export default function SettingsDialog({ children }: SettingsDialogProps) {
+export default function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const isDesktop = useMediaQuery('(min-width: 768px)')
-  const [open, setOpen] = useState(false)
   const router = useRouter()
   const { data: session, update } = useSession()
   const [name, setName] = useState(session?.user?.name || '')
@@ -66,7 +66,7 @@ export default function SettingsDialog({ children }: SettingsDialogProps) {
       
       router.refresh()
       toast({ title: 'Profile updated!' })
-      setOpen(false)
+      onOpenChange(false)
     } catch (error: any) {
       toast({
         title: 'Error updating profile',
@@ -132,8 +132,7 @@ export default function SettingsDialog({ children }: SettingsDialogProps) {
 
   if (isDesktop) {
     return (
-      <Dialog open={open} onOpenChange={setOpen}>
-        {children}
+      <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent className="p-6">
           <DialogHeader>
             <DialogTitle className="mb-4 flex items-center gap-1.5">
@@ -148,8 +147,7 @@ export default function SettingsDialog({ children }: SettingsDialogProps) {
   }
 
   return (
-    <Drawer open={open} onOpenChange={setOpen}>
-      {children}
+    <Drawer open={open} onOpenChange={onOpenChange}>
       <DrawerContent className="mb-6 rounded-xl bg-[#121212] px-6 py-4">
         <DrawerHeader className="text-left">
           <DrawerTitle className="mb-4 flex items-center gap-1.5">

--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -19,19 +19,29 @@ import { Input } from '@/components/ui/input'
 import { useMediaQuery } from '@/hooks/use-media-query'
 import { toast } from '@/hooks/use-toast'
 import { useSession } from 'next-auth/react'
-import { Image as ImageIcon, Save, Settings as SettingsIcon, User as UserIcon } from 'lucide-react'
+import {
+  Image as ImageIcon,
+  Save,
+  Settings as SettingsIcon,
+  User as UserIcon,
+  Loader2,
+} from 'lucide-react'
 
 interface SettingsDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
 }
 
-export default function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
+export default function SettingsDialog({
+  open,
+  onOpenChange,
+}: SettingsDialogProps) {
   const isDesktop = useMediaQuery('(min-width: 768px)')
   const router = useRouter()
   const { data: session, update } = useSession()
   const [name, setName] = useState(session?.user?.name || '')
   const [image, setImage] = useState(session?.user?.image || '')
+  const [isLoading, setIsLoading] = useState(false)
 
   useEffect(() => {
     setName(session?.user?.name || '')
@@ -40,30 +50,31 @@ export default function SettingsDialog({ open, onOpenChange }: SettingsDialogPro
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    
+    setIsLoading(true)
+
     try {
-      const payload = { 
+      const payload = {
         name: name.trim() || undefined,
-        image: image.trim() || undefined 
+        image: image.trim() || undefined,
       }
-      
+
       const res = await fetch('/api/user/settings', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       })
-      
+
       if (!res.ok) {
         const errorText = await res.text()
         throw new Error(errorText)
       }
-      
+
       // force a session update with the new data
       await update({
         name: payload.name,
         image: payload.image,
       })
-      
+
       router.refresh()
       toast({ title: 'Profile updated!' })
       onOpenChange(false)
@@ -73,6 +84,8 @@ export default function SettingsDialog({ open, onOpenChange }: SettingsDialogPro
         description: error.message,
         variant: 'destructive',
       })
+    } finally {
+      setIsLoading(false)
     }
   }
 
@@ -88,6 +101,7 @@ export default function SettingsDialog({ open, onOpenChange }: SettingsDialogPro
             className="pl-9"
             value={name}
             onChange={(e) => setName(e.target.value)}
+            disabled={isLoading}
           />
           <UserIcon
             size={16}
@@ -106,26 +120,38 @@ export default function SettingsDialog({ open, onOpenChange }: SettingsDialogPro
             value={image}
             onChange={(e) => setImage(e.target.value)}
             placeholder="https://example.com/image.jpg"
+            disabled={isLoading}
           />
-          <ImageIcon
-            size={16}
-            className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
-          />
-        </div>
-        {image && (
-          <div className="mt-2">
-            <p className="text-xs text-muted-foreground mb-2">Preview:</p>
-            <img 
-              src={image} 
-              alt="Profile preview" 
-              className="w-16 h-16 rounded-full object-cover border"
+          {image ? (
+            <img
+              src={image}
+              alt="Profile preview"
+              className="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border object-cover"
             />
-          </div>
-        )}
+          ) : (
+            <ImageIcon
+              size={16}
+              className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+            />
+          )}
+        </div>
       </div>
-      <Button type="submit" className="flex w-full items-center justify-center gap-2">
-        <Save size={16} />
-        <span>Save</span>
+      <Button
+        type="submit"
+        className="flex w-full items-center justify-center gap-2"
+        disabled={isLoading}
+      >
+        {isLoading ? (
+          <>
+            <Loader2 size={16} className="animate-spin" />
+            <span>Saving...</span>
+          </>
+        ) : (
+          <>
+            <Save size={16} />
+            <span>Save</span>
+          </>
+        )}
       </Button>
     </form>
   )
@@ -148,7 +174,7 @@ export default function SettingsDialog({ open, onOpenChange }: SettingsDialogPro
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent className="mb-6 rounded-xl bg-[#121212] px-6 py-4">
+      <DrawerContent className="mb-6 rounded-xl bg-background px-6 py-4">
         <DrawerHeader className="text-left">
           <DrawerTitle className="mb-4 flex items-center gap-1.5">
             <SettingsIcon size={18} className="opacity-80" />

--- a/components/user-dropdown.tsx
+++ b/components/user-dropdown.tsx
@@ -5,7 +5,6 @@
 import { Button } from '@/components/ui/button'
 import SettingsDialog from './settings-dialog'
 import ProfileDialog from './profile-dialog'
-import { DialogTrigger } from '@/components/ui/dialog'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,6 +34,8 @@ export const UserDropDown = ({
   img: string
 }) => {
   const [profileOpen, setProfileOpen] = React.useState(false)
+  const [settingsOpen, setSettingsOpen] = React.useState(false)
+  
   const handleSignOut = async () => {
     try {
       await signOut()
@@ -53,7 +54,6 @@ export const UserDropDown = ({
 
   return (
     <>
-    <SettingsDialog>
       <DropdownMenu>
         <DropdownMenuTrigger asChild className="group flex items-center">
           <Button
@@ -92,49 +92,31 @@ export const UserDropDown = ({
         <DropdownMenuGroup>
           {menuItems.map((item, index) => (
             <React.Fragment key={item.label}>
-              {item.isSettings ? (
-                <DialogTrigger asChild>
-                  <DropdownMenuItem
-                    className={`group cursor-pointer rounded-lg focus:bg-white ${
-                      index !== menuItems.length - 1 ? 'mb-1' : ''
-                    }`}
-                  >
-                    <div className="flex w-full items-center focus:shadow-md">
-                      <item.icon
-                        size={18}
-                        className="mr-3 h-4 w-4  text-dark/80 group-focus:text-black/90"
-                      />
-                      <span className="font-medium group-focus:text-black/90">
-                        {item.label}
-                      </span>
-                    </div>
-                  </DropdownMenuItem>
-                </DialogTrigger>
-              ) : (
-                <DropdownMenuItem
-                  className={`group cursor-pointer rounded-lg focus:bg-white ${
-                    index !== menuItems.length - 1 ? 'mb-1' : ''
-                  }`}
-                  key={item.href}
-                  onClick={() => {
-                    if (item.isProfile) {
-                      setProfileOpen(true)
-                    } else if (item.label === 'Logout') {
-                      handleSignOut()
-                    }
-                  }}
-                >
-                  <div className="flex w-full items-center focus:shadow-md">
-                    <item.icon
-                      size={18}
-                      className="mr-3 h-4 w-4  text-dark/80 group-focus:text-black/90"
-                    />
-                    <span className="font-medium group-focus:text-black/90">
-                      {item.label}
-                    </span>
-                  </div>
-                </DropdownMenuItem>
-              )}
+              <DropdownMenuItem
+                className={`group cursor-pointer rounded-lg focus:bg-white ${
+                  index !== menuItems.length - 1 ? 'mb-1' : ''
+                }`}
+                key={item.href}
+                onClick={() => {
+                  if (item.isProfile) {
+                    setProfileOpen(true)
+                  } else if (item.isSettings) {
+                    setSettingsOpen(true)
+                  } else if (item.label === 'Logout') {
+                    handleSignOut()
+                  }
+                }}
+              >
+                <div className="flex w-full items-center focus:shadow-md">
+                  <item.icon
+                    size={18}
+                    className="mr-3 h-4 w-4  text-dark/80 group-focus:text-black/90"
+                  />
+                  <span className="font-medium group-focus:text-black/90">
+                    {item.label}
+                  </span>
+                </div>
+              </DropdownMenuItem>
               {item.separateFromHere && (
                 <DropdownMenuSeparator
                   key={item.label}
@@ -146,7 +128,7 @@ export const UserDropDown = ({
         </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
-    </SettingsDialog>
+    <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
     <ProfileDialog open={profileOpen} onOpenChange={setProfileOpen} />
     </>
   )

--- a/components/user-dropdown.tsx
+++ b/components/user-dropdown.tsx
@@ -4,6 +4,7 @@
 
 import { Button } from '@/components/ui/button'
 import SettingsDialog from './settings-dialog'
+import ProfileDialog from './profile-dialog'
 import { DialogTrigger } from '@/components/ui/dialog'
 import {
   DropdownMenu,
@@ -20,7 +21,7 @@ import Image from 'next/image'
 import React from 'react'
 
 const menuItems = [
-  { href: '/profile', icon: User, label: 'Profile' },
+  { icon: User, label: 'Profile', isProfile: true },
   { icon: Settings, label: 'Settings', isSettings: true },
   { href: '/upgrade', icon: Zap, label: 'Upgrade', separateFromHere: true },
   { icon: LogOut, label: 'Logout' },
@@ -33,6 +34,7 @@ export const UserDropDown = ({
   username: string
   img: string
 }) => {
+  const [profileOpen, setProfileOpen] = React.useState(false)
   const handleSignOut = async () => {
     try {
       await signOut()
@@ -50,6 +52,7 @@ export const UserDropDown = ({
   }
 
   return (
+    <>
     <SettingsDialog>
       <DropdownMenu>
         <DropdownMenuTrigger asChild className="group flex items-center">
@@ -113,9 +116,13 @@ export const UserDropDown = ({
                     index !== menuItems.length - 1 ? 'mb-1' : ''
                   }`}
                   key={item.href}
-                  onClick={() =>
-                    item.label === 'Logout' ? handleSignOut() : null
-                  }
+                  onClick={() => {
+                    if (item.isProfile) {
+                      setProfileOpen(true)
+                    } else if (item.label === 'Logout') {
+                      handleSignOut()
+                    }
+                  }}
                 >
                   <div className="flex w-full items-center focus:shadow-md">
                     <item.icon
@@ -140,5 +147,7 @@ export const UserDropDown = ({
       </DropdownMenuContent>
     </DropdownMenu>
     </SettingsDialog>
+    <ProfileDialog open={profileOpen} onOpenChange={setProfileOpen} />
+    </>
   )
 }

--- a/next.config.js
+++ b/next.config.js
@@ -29,6 +29,11 @@ const nextConfig = {
       fullUrl: true,
     },
   },
+  compiler: {
+    removeConsole: {
+      exclude: ['error'],
+    },
+  },
 }
 
 module.exports = nextConfig

--- a/utils/auth-options.ts
+++ b/utils/auth-options.ts
@@ -13,7 +13,16 @@ declare module 'next-auth' {
     user: {
       id: string
       isCreator: boolean
+      createdAt: string | null
     } & DefaultSession['user']
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    id?: string
+    isCreator?: boolean
+    createdAt?: string | null
   }
 }
 
@@ -42,8 +51,9 @@ export const authOptions: NextAuthOptions = {
           name: user.name,
           email: user.email,
           image: user.image,
-          // @ts-expect-error isCreator is there but its not showing
+          // @ts-expect-error values come from Prisma but not in default type
           isCreator: user?.isCreator,
+          createdAt: (user as any)?.createdAt ?? null,
         }
       }
 
@@ -56,9 +66,10 @@ export const authOptions: NextAuthOptions = {
             email: true,
             image: true,
             isCreator: true,
+            createdAt: true,
           },
         })
-        
+
         if (dbUser) {
           return {
             ...token,
@@ -66,6 +77,7 @@ export const authOptions: NextAuthOptions = {
             email: dbUser.email,
             image: dbUser.image,
             isCreator: dbUser.isCreator,
+            createdAt: dbUser.createdAt?.toISOString() ?? null,
           }
         }
       }
@@ -82,6 +94,7 @@ export const authOptions: NextAuthOptions = {
           email: token.email as string | null,
           image: token.image as string | null,
           isCreator: token.isCreator as boolean,
+          createdAt: token.createdAt as string | null,
         },
       }
     },


### PR DESCRIPTION
## Summary
- add `ProfileDialog` component to show user avatar, name, and join date
- integrate profile dialog into the user dropdown
- expose `createdAt` in the user settings API

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch font `Plus Jakarta Sans` due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_6857fbc6d238832293bafe59411b9253