### PR TITLE
Fix dialog closing issue in dropdown

### DIFF
--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -22,12 +22,12 @@ import { useSession } from 'next-auth/react'
 import { Image as ImageIcon, Save, Settings as SettingsIcon, User as UserIcon } from 'lucide-react'
 
 interface SettingsDialogProps {
-  children: React.ReactNode
+  open: boolean
+  onOpenChange: (open: boolean) => void
 }
 
-export default function SettingsDialog({ children }: SettingsDialogProps) {
+export default function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const isDesktop = useMediaQuery('(min-width: 768px)')
-  const [open, setOpen] = useState(false)
   const router = useRouter()
   const { data: session, update } = useSession()
   const [name, setName] = useState(session?.user?.name || '')
@@ -66,7 +66,7 @@ export default function SettingsDialog({ children }: SettingsDialogProps) {
       
       router.refresh()
       toast({ title: 'Profile updated!' })
-      setOpen(false)
+      onOpenChange(false)
     } catch (error: any) {
       toast({
         title: 'Error updating profile',
@@ -132,8 +132,7 @@ export default function SettingsDialog({ children }: SettingsDialogProps) {
 
   if (isDesktop) {
     return (
-      <Dialog open={open} onOpenChange={setOpen}>
-        {children}
+      <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent className="p-6">
           <DialogHeader>
             <DialogTitle className="mb-4 flex items-center gap-1.5">
@@ -148,8 +147,7 @@ export default function SettingsDialog({ children }: SettingsDialogProps) {
   }
 
   return (
-    <Drawer open={open} onOpenChange={setOpen}>
-      {children}
+    <Drawer open={open} onOpenChange={onOpenChange}>
       <DrawerContent className="mb-6 rounded-xl bg-[#121212] px-6 py-4">
         <DrawerHeader className="text-left">
           <DrawerTitle className="mb-4 flex items-center gap-1.5">

--- a/components/user-dropdown.tsx
+++ b/components/user-dropdown.tsx
@@ -5,7 +5,6 @@
 import { Button } from '@/components/ui/button'
 import SettingsDialog from './settings-dialog'
 import ProfileDialog from './profile-dialog'
-import { DialogTrigger } from '@/components/ui/dialog'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,6 +34,8 @@ export const UserDropDown = ({
   img: string
 }) => {
   const [profileOpen, setProfileOpen] = React.useState(false)
+  const [settingsOpen, setSettingsOpen] = React.useState(false)
+  
   const handleSignOut = async () => {
     try {
       await signOut()
@@ -53,7 +54,6 @@ export const UserDropDown = ({
 
   return (
     <>
-    <SettingsDialog>
       <DropdownMenu>
         <DropdownMenuTrigger asChild className="group flex items-center">
           <Button
@@ -92,49 +92,31 @@ export const UserDropDown = ({
         <DropdownMenuGroup>
           {menuItems.map((item, index) => (
             <React.Fragment key={item.label}>
-              {item.isSettings ? (
-                <DialogTrigger asChild>
-                  <DropdownMenuItem
-                    className={`group cursor-pointer rounded-lg focus:bg-white ${
-                      index !== menuItems.length - 1 ? 'mb-1' : ''
-                    }`}
-                  >
-                    <div className="flex w-full items-center focus:shadow-md">
-                      <item.icon
-                        size={18}
-                        className="mr-3 h-4 w-4  text-dark/80 group-focus:text-black/90"
-                      />
-                      <span className="font-medium group-focus:text-black/90">
-                        {item.label}
-                      </span>
-                    </div>
-                  </DropdownMenuItem>
-                </DialogTrigger>
-              ) : (
-                <DropdownMenuItem
-                  className={`group cursor-pointer rounded-lg focus:bg-white ${
-                    index !== menuItems.length - 1 ? 'mb-1' : ''
-                  }`}
-                  key={item.href}
-                  onClick={() => {
-                    if (item.isProfile) {
-                      setProfileOpen(true)
-                    } else if (item.label === 'Logout') {
-                      handleSignOut()
-                    }
-                  }}
-                >
-                  <div className="flex w-full items-center focus:shadow-md">
-                    <item.icon
-                      size={18}
-                      className="mr-3 h-4 w-4  text-dark/80 group-focus:text-black/90"
-                    />
-                    <span className="font-medium group-focus:text-black/90">
-                      {item.label}
-                    </span>
-                  </div>
-                </DropdownMenuItem>
-              )}
+              <DropdownMenuItem
+                className={`group cursor-pointer rounded-lg focus:bg-white ${
+                  index !== menuItems.length - 1 ? 'mb-1' : ''
+                }`}
+                key={item.href}
+                onClick={() => {
+                  if (item.isProfile) {
+                    setProfileOpen(true)
+                  } else if (item.isSettings) {
+                    setSettingsOpen(true)
+                  } else if (item.label === 'Logout') {
+                    handleSignOut()
+                  }
+                }}
+              >
+                <div className="flex w-full items-center focus:shadow-md">
+                  <item.icon
+                    size={18}
+                    className="mr-3 h-4 w-4  text-dark/80 group-focus:text-black/90"
+                  />
+                  <span className="font-medium group-focus:text-black/90">
+                    {item.label}
+                  </span>
+                </div>
+              </DropdownMenuItem>
               {item.separateFromHere && (
                 <DropdownMenuSeparator
                   key={item.label}
@@ -146,7 +128,7 @@ export const UserDropDown = ({
         </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
-    </SettingsDialog>
+    <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
     <ProfileDialog open={profileOpen} onOpenChange={setProfileOpen} />
     </>
   )


### PR DESCRIPTION
Convert `SettingsDialog` to a controlled component to fix immediate closing when opened from a dropdown.

The original problem was that using `DialogTrigger` inside a dropdown menu causes the dropdown to close immediately when the dialog opens due to event bubbling and focus management conflicts. This change adopts a controlled dialog pattern, which is the recommended approach for such scenarios in shadcn/ui.